### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/albums-api/Controllers/UnsecuredController.cs
+++ b/albums-api/Controllers/UnsecuredController.cs
@@ -10,18 +10,30 @@ namespace UnsecureApp.Controllers
 
         public string ReadFile(string userInput)
         {
-            using (FileStream fs = File.Open(userInput, FileMode.Open))
+            if (IsValidPath(userInput))
             {
-                byte[] b = new byte[1024];
-                UTF8Encoding temp = new UTF8Encoding(true);
-
-                while (fs.Read(b, 0, b.Length) > 0)
+                using (FileStream fs = File.Open(userInput, FileMode.Open))
                 {
-                    return temp.GetString(b);
+                    byte[] b = new byte[1024];
+                    UTF8Encoding temp = new UTF8Encoding(true);
+
+                    while (fs.Read(b, 0, b.Length) > 0)
+                    {
+                        return temp.GetString(b);
+                    }
                 }
+            }
+            else
+            {
+                throw new ArgumentException("Invalid file path.");
             }
 
             return null;
+        }
+
+        private bool IsValidPath(string path)
+        {
+            return !(path.Contains("..") || path.Contains("/") || path.Contains("\\"));
         }
 
         public int GetProduct(string productName)


### PR DESCRIPTION
Fixes [https://github.com/geovanams/GHASteste/security/code-scanning/1](https://github.com/geovanams/GHASteste/security/code-scanning/1)

To fix the problem, we need to validate the `userInput` before using it to construct a file path. We will ensure that the `userInput` does not contain any path separators or parent directory references. If the input should be within a specific directory, we will check that the resolved path is still contained within that directory.

1. Add a method to validate the `userInput` to ensure it does not contain any path separators or parent directory references.
2. Use this validation method before opening the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
